### PR TITLE
Fix application crash when Datadog API unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,5 @@ go install github.com/kisielk/errcheck@latest
 go install github.com/securego/gosec/v2/cmd/gosec@latest
 go install golang.org/x/vuln/cmd/govulncheck@latest
 go install github.com/oligot/go-mod-upgrade@latest
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 ```

--- a/server/batch.go
+++ b/server/batch.go
@@ -3,22 +3,14 @@ package server
 import (
 	"context"
 	"dd-log-proxy/logentry"
-	"os"
-	"strconv"
 	"time"
 
 	log "github.com/jlentink/yaglogger"
 )
 
-func createBatch(serverContext context.Context, channel chan logentry.LogEntry) []logentry.LogEntry {
+func createBatch(serverContext context.Context, channel chan logentry.LogEntry, maxItemsInBatch int, maxWaitTime time.Duration) []logentry.LogEntry {
 	batchStartTime := time.Now()
 	itemsInBatch := 0
-	maxItemsInBatch, maxItemsInBatchError := strconv.Atoi(os.Getenv("BATCH_SIZE"))
-	maxWaitTimeInSeconds, maxWaitTimeInSecondsError := strconv.Atoi(os.Getenv("BATCH_WAIT_IN_SECONDS"))
-
-	if maxItemsInBatchError != nil || maxWaitTimeInSecondsError != nil {
-		log.Fatal("Unable to retrieve batch config from environment variables!")
-	}
 
 	var batch []logentry.LogEntry
 
@@ -35,7 +27,7 @@ func createBatch(serverContext context.Context, channel chan logentry.LogEntry) 
 			time.Sleep(100 * time.Millisecond)
 		}
 
-		if time.Now().After(batchStartTime.Add(time.Duration(maxWaitTimeInSeconds)*time.Second)) && itemsInBatch > 0 {
+		if time.Now().After(batchStartTime.Add(maxWaitTime)) && itemsInBatch > 0 {
 			log.Info("Max wait time reached, sending %d messages which are waiting in the batch", itemsInBatch)
 			break
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -34,7 +34,7 @@ func Start() {
 
 	udpServer, err := net.ListenPacket("udp", os.Getenv("HOST")+":"+os.Getenv("PORT"))
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatal("Could not start UDP server on '%s': %v", os.Getenv("HOST")+":"+os.Getenv("PORT"), err)
 	}
 
 	go waitForUDPMessage(channel, udpServer)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,8 +4,6 @@ import (
 	"dd-log-proxy/logentry"
 	"net"
 	"testing"
-
-	log "github.com/jlentink/yaglogger"
 )
 
 func Test_handleUDPMessage(t *testing.T) {
@@ -35,14 +33,14 @@ func Test_handleWrongUDPMessage(t *testing.T) {
 
 func Test_waitForUDPMessage(t *testing.T) {
 	udpServer, err := net.ListenPacket("udp", "127.0.0.1:1337")
-	defer udpServer.Close()
 	if err != nil {
-		log.Fatal(err.Error())
+		t.Fatal("could not start udpServer: ", err)
 	}
+	defer udpServer.Close()
 
 	conn, err := net.Dial("udp", "127.0.0.1:1337")
 	if err != nil {
-		t.Error("could not connect to server: ", err)
+		t.Error("could not connect to server:", err)
 	}
 
 	channel := make(chan logentry.LogEntry)
@@ -57,7 +55,7 @@ func Test_waitForUDPMessage(t *testing.T) {
 func Test_waitForUDPMessageFailure(t *testing.T) {
 	udpServer, err := net.ListenPacket("udp", "127.0.0.1:1337")
 	if err != nil {
-		log.Fatal(err.Error())
+		t.Fatal("could not start udpServer:", err)
 	}
 
 	channel := make(chan logentry.LogEntry)


### PR DESCRIPTION
**Changes**
- Fix the application crashing when the Datadog API is momentarily unavailable.
- Change signature of internal method `batch.createBatch` to take in items and duration instead of fetching from environment variables.

**Testing**
- Improve error handling of existing server tests.
- Change the batching tests to use one helper function.
- Add test to check context cancel of `handleLogEntries`.